### PR TITLE
Remove unneeded comments...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,17 +9,12 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 
-# commented by adam
-# gem "jekyll", "~> 3.8.1"
-# added by adam from https://jekyllrb.com/docs/github-pages/
-gem "github-pages", group: :jekyll_plugins
-
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do


### PR DESCRIPTION
@a-schaefers I think we can just remove the comments about replacing the jeykll gem with the github-pages gem, since it's noted later on in the same Gemfile. Think we can get away with just uncommenting the line there and deleting the jekyll gem reference entirely from the file as noted in the comments.

Look good to you?